### PR TITLE
Escape slash quotes

### DIFF
--- a/android/app-json.gradle
+++ b/android/app-json.gradle
@@ -52,7 +52,7 @@ if (configFile != null && configFile.exists()) {
         );
       } catch (e) {
         if (e instanceof Error && e.code === "MODULE_NOT_FOUND") {
-          console.error("You have an expo app.config[.js|.ts] file but do not have \"@expo/config\" installed. \"@expo/config\" is required for react-native-google-mobile-ads to read the app.config[.js|.ts] file and should be installed by default with expo. Please install \"@expo/config\" and try again.")
+          console.error("You have an expo app.config[.js|.ts] file but do not have \\"@expo/config\\" installed. \\"@expo/config\\" is required for react-native-google-mobile-ads to read the app.config[.js|.ts] file and should be installed by default with expo. Please install \\"@expo/config\\" and try again.")
         } else {
           throw e
         }


### PR DESCRIPTION
I have escaped the slash quotes because I think gradle escapes the `\"` -> `"` which causes javascript to fail. I have escaped `\"` so that it preserves the `\"` for js to escape.

I haven't tested this myself, but hopefully it should fix the problem.

Edit: It fixed the problem. This PR fixes the issue!